### PR TITLE
Add "Support & Consulting" link

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -7,6 +7,7 @@
             <b>Help</b>
             <NuxtLink class="hover:underline w-fit" to="https://github.com/epicmaxco/vuestic-admin/releases/epicmaxco/vuestic-admin" target="_blank">Report a Bug</NuxtLink>
             <NuxtLink class="hover:underline w-fit" to="https://github.com/epicmaxco/vuestic-admin/releases/vuestic-admin/releases/epicmaxco/vuestic-admin" target="_blank">Release Log</NuxtLink>
+            <NuxtLink class="hover:underline w-fit" to="https://ui.vuestic.dev/support/consulting" target="_blank">Support & Consulting</NuxtLink>
           </div>
           <div class="flex flex-col gap-3 order-2 md:order-2">
             <b>Community</b>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -58,6 +58,11 @@ defineProps({
 })
 
 const menuItems = {
+  support: {
+    to: 'https://ui.vuestic.dev/support/consulting',
+    name: 'Support & Consulting',
+    target: '_blank',
+  },
   contribute: {
     to: 'https://ui.vuestic.dev/contribution/guide',
     name: 'Contribute',


### PR DESCRIPTION
Adds "Support & Consulting" link to the landing

### Before:
![image](https://github.com/user-attachments/assets/75623f9c-71cf-48db-980c-b5f88c457395)
![image](https://github.com/user-attachments/assets/ef4a3908-f023-417f-b359-7554d0b9060a)

### After:
![image](https://github.com/user-attachments/assets/314f90b1-a26d-42c8-8dd8-75fb8ec687bd)
![image](https://github.com/user-attachments/assets/7da1dc9b-fef8-4cb8-82da-028499cda667)
